### PR TITLE
Making with_label accept an object responding to match

### DIFF
--- a/lib/lifx/light_collection.rb
+++ b/lib/lifx/light_collection.rb
@@ -21,7 +21,7 @@ module LIFX
     # Creates a {LightCollection} instance. Should not be used directly.
     # @api private
     # @param context: [NetworkContext] NetworkContext this collection belongs to
-    # @param tag: [String] Tag 
+    # @param tag: [String] Tag
     def initialize(context:, tag: nil)
       @context = context
       @tag = tag
@@ -52,11 +52,7 @@ module LIFX
     # @param label [String, Regexp] Label
     # @return [Light]
     def with_label(label)
-      if label.is_a?(Regexp)
-        lights.find { |l| l.label(fetch: false) =~ label }
-      else
-        lights.find { |l| l.label(fetch: false) == label }
-      end
+      lights.find { |l| label.match l.label(fetch: false) }
     end
 
     # Returns a {LightCollection} of {Light}s tagged with `tag`

--- a/spec/lifx/light_collection_spec.rb
+++ b/spec/lifx/light_collection_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module LIFX
+  describe LightCollection do
+    subject(:collection) { LightCollection.new(context: context) }
+
+    let(:context) { double(:context).as_null_object }
+
+    describe '#with_label' do
+      let(:light) { double(:light, label: 'Test') }
+
+      before { collection.stub(lights: [light]) }
+
+      shared_examples 'returning the matching Light' do
+        it 'returns the first light with a matching label' do
+          expect(collection.with_label(label)).to be light
+        end
+      end
+
+      context 'when the given label is a String' do
+        let(:label) { 'Test' }
+        it_behaves_like 'returning the matching Light'
+      end
+
+      context 'when the given label is a Regexp' do
+        let(:label) { /Test/ }
+        it_behaves_like 'returning the matching Light'
+      end
+
+      context 'when the label is an object responding to match' do
+        let(:label) { double(:label, match: true) }
+        it_behaves_like 'returning the matching Light'
+      end
+
+      context 'when no light matches' do
+        let(:light) { double(:light, label: 'Other') }
+
+        it 'returns nil' do
+          expect(collection.with_label('Test')).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current implementation of `with_label` accepts only a String
or a Regexp to be passed to match a light's label.

This commit simplifies the code and in the same time provides the
ability to give any object responding to `match` as a label.

String and Regexp both implement the `match` method, the original
behavior still works but it opens the door to other possibilities.
