### PR TITLE
Cleaning up the specs

### DIFF
--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -3,42 +3,23 @@ require 'spec_helper'
 module LIFX
   describe Color do
     let(:default_kelvin) { 3500 }
+
     describe '.rgb' do
       context 'translating from RGB' do
-        it 'translates red correctly' do
-          c = Color.rgb(255, 0, 0)
-          c.to_a.should == [0, 1, 1, default_kelvin]
+        shared_examples 'translating color' do |name, rgb, expected|
+          it "translates #{name} correctly" do
+            translation = Color.rgb(*rgb).to_a
+            expect(translation).to eq [*expected, default_kelvin]
+          end
         end
 
-        it 'translates yellow correctly' do
-          c = Color.rgb(255, 255, 0)
-          c.to_a.should == [60, 1, 1, default_kelvin]
-        end
-
-        it 'translates green correctly' do
-          c = Color.rgb(0, 255, 0)
-          c.to_a.should == [120, 1, 1, default_kelvin]
-        end
-
-        it 'translates cyan correctly' do
-          c = Color.rgb(0, 255, 255)
-          c.to_a.should == [180, 1, 1, default_kelvin]
-        end
-
-        it 'translates blue correctly' do
-          c = Color.rgb(0, 0, 255)
-          c.to_a.should == [240, 1, 1, default_kelvin]
-        end
-
-        it 'translates white correctly' do
-          c = Color.rgb(255, 255, 255)
-          c.to_a.should == [0, 0, 1, default_kelvin]
-        end
-
-        it 'translates black correctly' do
-          c = Color.rgb(0, 0, 0)
-          c.to_a.should == [0, 0, 0, default_kelvin]
-        end
+        it_behaves_like 'translating color', 'red',    [255, 0, 0],     [0, 1, 1]
+        it_behaves_like 'translating color', 'yellow', [255, 255, 0],   [60, 1, 1]
+        it_behaves_like 'translating color', 'green',  [0, 255, 0],     [120, 1, 1]
+        it_behaves_like 'translating color', 'cyan',   [0, 255, 255],   [180, 1, 1]
+        it_behaves_like 'translating color', 'blue',   [0, 0, 255],     [240, 1, 1]
+        it_behaves_like 'translating color', 'white',  [255, 255, 255], [0, 0, 1]
+        it_behaves_like 'translating color', 'black',  [0, 0, 0],       [0, 0, 0]
       end
     end
   end

--- a/spec/gateway_connection_spec.rb
+++ b/spec/gateway_connection_spec.rb
@@ -2,30 +2,26 @@ require 'spec_helper'
 
 module LIFX
   describe GatewayConnection do
-    subject do
-      GatewayConnection.new
-    end
+    subject(:gateway) { GatewayConnection.new }
 
-    let(:message) { double(Message).tap { |m| m.stub(:is_a?).and_return(true); m.stub(:pack) } }
+    let(:message) { double(Message, is_a?: true, pack: '') }
     let(:ip) { '127.0.0.1' }
-    let(:port) { 35003 }
+    let(:port) { 35_003 }
 
-    after do
-      subject.close
-    end
+    after { gateway.close }
 
     context 'write queue resiliency' do
       it 'does not send if there is no available connection' do
-        expect(subject).to_not receive(:actually_write)
-        subject.write(message)
-        expect { subject.flush(timeout: 0.5) }.to raise_error(Timeout::Error)
+        expect(gateway).to_not receive(:actually_write)
+        gateway.write(message)
+        expect { gateway.flush(timeout: 0.5) }.to raise_error(Timeout::Error)
       end
-      
+
       it 'pushes message back into queue if unable to write' do
-        subject.connect_udp(ip, port)
-        expect(subject).to receive(:actually_write).and_return(false, true)
-        subject.write(message)
-        subject.flush
+        gateway.connect_udp(ip, port)
+        expect(gateway).to receive(:actually_write).and_return(false, true)
+        gateway.write(message)
+        gateway.flush
       end
     end
   end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -3,35 +3,35 @@ require 'spec_helper'
 module LIFX
   describe Client, integration: true do
     describe '#sync' do
+      let(:minimum_lights) { 3 }
+      let(:udp) { Transport::UDP.new('0.0.0.0', 56_750) }
+      let(:white) { Color.white(brightness: 0.5) }
+
       it 'schedules sending all messages to be executed at the same time' do
-        if lights.count < 3
-          pending "This test requires 3 or more lights tagged under Test"
+        if lights.count < minimum_lights
+          pending 'This test requires 3 or more lights tagged under Test'
           return
         end
 
-        lifx.discover! do
-          lights.count >= 3
-        end
+        lifx.discover! { lights.count >= minimum_lights }
 
-        white = LIFX::Color.white(brightness: 0.5)
         lights.set_color(white, duration: 0)
         sleep 1
 
-        udp = Transport::UDP.new('0.0.0.0', 56750)
         msgs = []
         udp.add_observer(self) do |message:, ip:, transport:|
           msgs << message if message.payload.is_a?(Protocol::Light::SetWaveform)
         end
         udp.listen
 
-        delay = lifx.sync do
+        lifx.sync do
           lights.each do |light|
             light.pulse(LIFX::Color.hsb(rand(360), 1, 1), period: 1)
           end
         end
 
-        msgs.count.should == lights.count
-        msgs.map(&:at_time).uniq.count.should == 1
+        expect(msgs.count).to eq lights.count
+        expect(msgs.map(&:at_time).uniq.count).to eq 1
 
         flush
       end

--- a/spec/integration/light_spec.rb
+++ b/spec/integration/light_spec.rb
@@ -3,41 +3,41 @@ require 'spec_helper'
 module LIFX
   describe Light, integration: true do
     describe '#set_power' do
-      it "sets the power of the light asynchronously" do
+      it 'sets the power of the light asynchronously' do
         light.set_power(0)
-        wait { light.off?.should == true }
+        wait { expect(light).to be_off }
         light.set_power(1)
-        wait { light.on?.should == true }
+        wait { expect(light).to be_on }
       end
     end
 
     describe '#set_power!' do
-      it "sets the power of the light synchronously" do
+      it 'sets the power of the light synchronously' do
         light.set_power!(0)
-        light.off?.should == true
+        expect(light).to be_off
         light.set_power!(1)
-        light.on?.should == true
+        expect(light).to be_on
       end
     end
 
     describe '#set_color' do
-      it "sets the color of the light asynchronously" do
-        color = Color.hsb(rand(360), rand, rand)
+      let(:color) { Color.hsb(rand(360), rand, rand) }
+
+      it 'sets the color of the light asynchronously' do
         light.set_color(color, duration: 0)
         sleep 1
         light.refresh
-        wait { light.color.should == color }
+        wait { expect(light.color).to eq color }
       end
     end
 
     describe '#set_label' do
-      it "sets the label of the light synchronously" do
-        label = light.label.sub(/\d+|$/, rand(100).to_s)
+      let(:label) { light.label.sub(/\d+|$/, rand(100).to_s) }
+
+      it 'sets the label of the light synchronously' do
         light.set_label(label)
-        light.label.should == label
+        expect(light.label).to eq label
       end
     end
-
-
   end
 end

--- a/spec/integration/tags_spec.rb
+++ b/spec/integration/tags_spec.rb
@@ -1,31 +1,33 @@
 require 'spec_helper'
 
 module LIFX
-  describe "tags", integration: true do
-    it 'Clearing, setting and using tags' do
+  describe 'tags', integration: true do
+    let(:color) { Color.hsb(rand(360), 0.3, 0.3) }
+
+    specify 'Clearing, setting and using tags' do
       light.add_tag('Foo')
-      light.tags.should include('Foo')
+      expect(light.tags).to include('Foo')
 
       test_tag = lights.with_tag('Foo')
       test_tag.turn_on
-      color = Color.hsb(rand(360), 0.3, 0.3)
-      test_tag.set_color(color, duration: 0) 
+      test_tag.set_color(color, duration: 0)
       flush
       sleep 1 # Set messages are scheduled 250ms if no at_time is set
-              # It also returns the current light state rather than the final state
+              # It also returns the current light state rather than the
+              # final state
       light.refresh
-      wait { light.color.should == color }
+      wait { expect(light.color).to eq color }
 
       light.remove_tag('Foo')
-      wait { light.tags.should_not include('Foo') }
+      wait { expect(light.tags).not_to include('Foo') }
     end
 
     it 'deletes tags when no longer assigned to a light' do
       light.add_tag('TempTag')
       light.remove_tag('TempTag')
-      lifx.unused_tags.should include('TempTag')
+      expect(lifx.unused_tags).to include('TempTag')
       lifx.purge_unused_tags!
-      lifx.unused_tags.should be_empty
+      expect(lifx.unused_tags).to be_empty
     end
   end
 end

--- a/spec/protocol_path_spec.rb
+++ b/spec/protocol_path_spec.rb
@@ -3,47 +3,49 @@ require 'spec_helper'
 module LIFX
   describe ProtocolPath do
     describe 'initializing from raw data' do
+      subject do
+        ProtocolPath.new(raw_site: '1lifx1', raw_target: target, tagged: tagged)
+      end
+
       context 'device target' do
-        subject do
-          ProtocolPath.new(raw_site: "1lifx1", raw_target: "\xAB\xCD\xEF\x12\x34\x56\x00\x00", tagged: false)
-        end
+        let(:target) { "\xAB\xCD\xEF\x12\x34\x56\x00\x00" }
+        let(:tagged) { false }
 
         it 'returns site_id in hex' do
-          subject.site_id.should == "316c69667831"
+          expect(subject.site_id).to eq '316c69667831'
         end
 
         it 'returns device_id in hex' do
-          subject.device_id.should == 'abcdef123456'
+          expect(subject.device_id).to eq 'abcdef123456'
         end
 
         it 'returns tagged as false' do
-          subject.tagged?.should be_false
+          expect(subject).not_to be_tagged
         end
 
         it 'returns nil for tag_ids' do
-          subject.tag_ids.should == nil
+          expect(subject.tag_ids).to be_nil
         end
       end
 
       context 'tagged target' do
-        subject do
-          ProtocolPath.new(raw_site: "1lifx1", raw_target: "\x03\x00\x00\x00\x00\x00\x00\x00", tagged: true)
-        end
+        let(:target) { "\x03\x00\x00\x00\x00\x00\x00\x00" }
+        let(:tagged) { true }
 
         it 'returns site_id in hex' do
-          subject.site_id.should == "316c69667831"
+          expect(subject.site_id).to eq '316c69667831'
         end
 
         it 'returns device_id as nil' do
-          subject.device_id.should == nil
+          expect(subject.device_id).to be_nil
         end
 
         it 'returns tagged as true' do
-          subject.tagged?.should be_true
+          expect(subject).to be_tagged
         end
 
         it 'returns the tag_ids' do
-          subject.tag_ids.should == [0, 1]
+          expect(subject.tag_ids).to eq [0, 1]
         end
       end
     end
@@ -51,11 +53,11 @@ module LIFX
     describe 'initializing from strings' do
       context 'device target' do
         subject do
-          ProtocolPath.new(site_id: "316c69667831", device_id: 'abcdef123456')
+          ProtocolPath.new(site_id: '316c69667831', device_id: 'abcdef123456')
         end
 
         it 'sets raw_site correctly' do
-          subject.raw_site.should == "1lifx1"
+          expect(subject.raw_site).to eq '1lifx1'
         end
 
         it 'sets raw_target correctly' do
@@ -69,41 +71,37 @@ module LIFX
 
       context 'tagged target' do
         subject do
-          ProtocolPath.new(site_id: "316c69667831", tag_ids: [0, 1])
+          ProtocolPath.new(site_id: '316c69667831', tag_ids: [0, 1])
         end
 
         it 'sets raw_site properly' do
-          subject.raw_site.should == "1lifx1"
+          expect(subject.raw_site).to eq '1lifx1'
         end
 
         it 'sets raw_target correctly' do
-          subject.raw_target.should == "\x03\x00\x00\x00\x00\x00\x00\x00".b
+          expect(subject.raw_target).to eq "\x03\x00\x00\x00\x00\x00\x00\x00".b
         end
 
         it 'returns tagged as true' do
-          subject.tagged?.should be_true
+          expect(subject).to be_tagged
         end
       end
 
       context 'tagged target with no site' do
-        subject do
-          ProtocolPath.new(tagged: true)
-        end
+        subject { ProtocolPath.new(tagged: true) }
 
         it 'raw_site should be null string' do
-          subject.raw_site.should == "\x00\x00\x00\x00\x00\x00".b
+          expect(subject.raw_site).to eq "\x00\x00\x00\x00\x00\x00".b
         end
 
         it 'sets raw_target correctly' do
-          subject.raw_target.should == "\x00\x00\x00\x00\x00\x00\x00\x00".b
+          expect(subject.raw_target).to eq "\x00\x00\x00\x00\x00\x00\x00\x00".b
         end
 
         it 'returns tagged as true' do
-          subject.tagged?.should be_true
+          expect(subject).to be_tagged
         end
       end
-
     end
-
   end
 end

--- a/spec/routing_manager_spec.rb
+++ b/spec/routing_manager_spec.rb
@@ -3,19 +3,20 @@ require 'spec_helper'
 module LIFX
   describe RoutingManager do
     describe '#tags_for_device_id' do
-      subject do
-        RoutingManager.new(context: double)
-      end
+      subject(:manager) { RoutingManager.new(context: double) }
 
       before do
-        subject.tag_table.update_table(site_id: 'site', tag_id: 0, label: 'Some label')
-        subject.tag_table.update_table(site_id: 'site', tag_id: 1, label: 'Another label')
-        subject.tag_table.update_table(site_id: 'site', tag_id: 2, label: 'Much label')
-        subject.routing_table.update_table(site_id: 'site', device_id: 'device', tag_ids: [0,2])
+        ['Some label', 'Another label', 'Much label'].each_with_index do |lbl, i|
+          manager.tag_table.update_table(site_id: 'site', tag_id: i, label: lbl)
+        end
+
+        manager.routing_table
+               .update_table(site_id: 'site', device_id: 'device', tag_ids: [0, 2])
       end
 
       it 'resolves tags' do
-        subject.tags_for_device_id('device').should == ['Some label', 'Much label']
+        tags = manager.tags_for_device_id('device')
+        expect(tags).to eq ['Some label', 'Much label']
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,12 +41,9 @@ shared_context 'integration', integration: true do
   let(:light) { lights.first }
 end
 
-if ENV['DEBUG']
-  LIFX::Config.logger = Yell.new(STDERR)
-end
+LIFX::Config.logger = Yell.new(STDERR) if ENV['DEBUG']
 
 RSpec.configure do |config|
   config.formatter = 'documentation'
   config.color = true
 end
-

--- a/spec/transport/udp_spec.rb
+++ b/spec/transport/udp_spec.rb
@@ -1,38 +1,40 @@
 require 'spec_helper'
 
 describe LIFX::Transport::UDP do
-  let(:port) { 45828 }
-  subject do
-    LIFX::Transport::UDP.new('localhost', port)
-  end
+  subject(:udp) { LIFX::Transport::UDP.new(host, port) }
+
+  let(:host) { 'localhost' }
+  let(:message) { double }
+  let(:port) { 45_828 }
 
   describe '#write' do
-    let(:message) { double }
     let(:payload) { double }
+
     it 'writes a Message to specified host' do
-      message.should_receive(:pack).and_return(payload)
-      UDPSocket.any_instance.should_receive(:send).with(payload, 0, 'localhost', port)
-      subject.write(message)
+      expect(message).to receive(:pack).and_return(payload)
+      expect_any_instance_of(UDPSocket).to receive(:send)
+                                           .with(payload, 0, host, port)
+      udp.write(message)
     end
   end
 
   describe '#listen' do
     let(:raw_message) { 'some binary data' }
-    let(:message) { double }
     let(:socket) { UDPSocket.new }
 
     it 'listens to the specified socket data, unpacks it and notifies observers' do
       messages = []
-      subject.add_observer(self) do |message:, ip:, transport:|
+      udp.add_observer(self) do |message:, ip:, transport:|
         messages << message
       end
-      subject.listen
+      udp.listen
 
-      LIFX::Message.should_receive(:unpack).with(raw_message).and_return(message)
-      socket.send(raw_message, 0, 'localhost', port)
+      expect(LIFX::Message).to receive(:unpack)
+                               .with(raw_message)
+                               .and_return(message)
+      socket.send(raw_message, 0, host, port)
       sleep 0.01
-      messages.should include(message)
+      expect(messages).to include(message)
     end
-
   end
 end

--- a/spec/transport_spec.rb
+++ b/spec/transport_spec.rb
@@ -6,9 +6,9 @@ describe LIFX::Transport do
 
   describe 'initialize' do
     it 'takes an host and port' do
-      transport = LIFX::Transport.new('127.0.0.1', 31337)
-      transport.host.should == '127.0.0.1'
-      transport.port.should == 31337
+      transport = LIFX::Transport.new('127.0.0.1', 31_337)
+      expect(transport.host).to eq '127.0.0.1'
+      expect(transport.port).to eq 31_337
     end
   end
 end


### PR DESCRIPTION
This commit cleans up the specs, using `expect` instead of `should`,
using `let` instead of local variables, removing unused assignations,
using an `_` for long numbers, using shared examples, etc.
