### PR TITLE
Use fully-qualified name for DiscoveryTimeout in spec/spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ shared_context 'integration', integration: true do
         c.discover! do
           c.tags.include?('_Test') && c.lights.with_tag('_Test').count > 0
         end
-      rescue DiscoveryTimeout
+      rescue LIFX::Client::DiscoveryTimeout
         raise "Could not find any lights with tag _Test in #{c.lights.inspect}"
       end
       c


### PR DESCRIPTION
When I ran the tests locally, it complained about this constant being missing. Using the fully-qualified named for the constant removed these errors.

```
LIFX::Client
  #sync
    schedules sending all messages to be executed at the same time (FAILED - 1)

Failures:

  1) LIFX::Client#sync schedules sending all messages to be executed at the same time
     Failure/Error: if lights.count < minimum_lights
     NameError:
       uninitialized constant DiscoveryTimeout
     # ./spec/spec_helper.rb:19:in `rescue in lifx'
     # ./spec/spec_helper.rb:15:in `lifx'
     # ./spec/spec_helper.rb:30:in `block (2 levels) in <top (required)>'
     # ./spec/integration/client_spec.rb:11:in `block (3 levels) in <module:LIFX>'
```

I ran the tests with `bundle exec rspec spec`, instead of `bundle exec rake`.
