### PR TITLE
Bump to RSpec 3

### DIFF
--- a/lifx.gemspec
+++ b/lifx.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "configatron", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rspec", "~> 3.0.0"
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -41,7 +41,7 @@ describe LIFX::Message do
     it 'returns the payload' do
       expect(payload.class).to eq LIFX::Protocol::Light::SetWaveform
       expect(payload.stream).to eq 0
-      expect(payload.transient).to be_true
+      expect(payload.transient).to be_truthy
       expect(payload.color.hue).to eq 0
       expect(payload.color.saturation).to eq 65_535
       expect(payload.color.brightness).to eq 65_535

--- a/spec/protocol_path_spec.rb
+++ b/spec/protocol_path_spec.rb
@@ -65,7 +65,7 @@ module LIFX
         end
 
         it 'sets tagged to false' do
-          subject.tagged?.should be_false
+          subject.tagged?.should be false
         end
       end
 


### PR DESCRIPTION
I noticed two deprecation warnings on the test suite and wondered if it would be possible to fix these and then possibly upgrade the gem to use RSpec 3. Yes to both.
