### PR TITLE
Use stdlib logger in identify example

### DIFF
--- a/examples/identify/identify.rb
+++ b/examples/identify/identify.rb
@@ -16,7 +16,7 @@ COLOURS = {
   'blue' => [220, 1, 1]
 }
 
-LIFX::Config.logger = Yell.new(STDERR, :level => :error)
+LIFX::Config.logger = Logger.new(STDERR)
 c = LIFX::Client.lan
 c.discover
 5.times do


### PR DESCRIPTION
Yell is no longer used and it seems that `Logger` does what is necessary.
