### PR TITLE
remove bundle warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :test do
   gem 'rake', '~> 10.1'
-  gem 'rspec', '~> 2.14'
+  gem 'rspec', '~> 3.0.0'
 end
 
 # Specify your gem's dependencies in lifx.gemspec

--- a/lifx.gemspec
+++ b/lifx.gemspec
@@ -23,6 +23,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "timers", "~> 1.0"
   spec.add_dependency "configatron", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.1"
-  spec.add_development_dependency "rspec", "~> 3.0.0"
 end


### PR DESCRIPTION
This removes the warnings caused by duplicated rake dependencies (when installing with bundle), the same has been done for rspec
