### PR TITLE
remove rspec deprecation warnings

### DIFF
--- a/spec/light_collection_spec.rb
+++ b/spec/light_collection_spec.rb
@@ -5,30 +5,28 @@ module LIFX
     subject(:collection) { LightCollection.new(context: double) }
 
     describe '#with_id' do
+      let(:light) { double(Light, id: 'id') }
+      before { allow(collection).to receive(:lights).and_return([light]) }
+
       it 'returns a Light with matching id' do
-        light = double(Light, id: 'id')
-        collection.stub(lights: [light])
         expect(collection.with_id('id')).to eq light
       end
 
       it 'returns nil when none matches' do
-        light = double(Light, id: 'id')
-        collection.stub(lights: [light])
         ret = collection.with_id('wrong id')
         expect(ret).to eq nil
       end
     end
 
     describe '#with_label' do
+      let(:light) { double(Light, label: 'label') }
+      before { allow(collection).to receive(:lights).and_return([light]) }
+
       it 'returns a Light with matching label' do
-        light = double(Light, label: 'label')
-        collection.stub(lights: [light])
         expect(collection.with_label('label')).to eq light
       end
 
       it 'returns nil' do
-        light = double(Light, label: 'label')
-        collection.stub(lights: [light])
         ret = collection.with_label('wrong label')
         expect(ret).to eq nil
       end

--- a/spec/protocol_path_spec.rb
+++ b/spec/protocol_path_spec.rb
@@ -61,11 +61,11 @@ module LIFX
         end
 
         it 'sets raw_target correctly' do
-          subject.raw_target.should == "\xAB\xCD\xEF\x12\x34\x56\x00\x00".b
+          expect(subject.raw_target).to eq "\xAB\xCD\xEF\x12\x34\x56\x00\x00".b
         end
 
         it 'sets tagged to false' do
-          subject.tagged?.should be false
+          expect(subject).to_not be_tagged
         end
       end
 


### PR DESCRIPTION
Since now rspec is updated on the gemfile, is now catching some deprecation caused by the use of should and stub
